### PR TITLE
Fix hmac and php notice

### DIFF
--- a/src/Signers/Hmac.php
+++ b/src/Signers/Hmac.php
@@ -36,6 +36,6 @@ class Hmac extends AbstractSigner
      */
     public function verify(string $mustSign,string $signedBefore): bool
     {
-        return hash_equals($this->sign($mustSign),$signedBefore) == 0;
+        return hash_equals($this->sign($mustSign),$signedBefore);
     }
 }

--- a/src/UrlSigner.php
+++ b/src/UrlSigner.php
@@ -83,7 +83,7 @@ class UrlSigner implements UrlSignerInterface
 
         parse_str($parsedUrl['query'] ?? '', $params);
 
-        $this->clearUrl($url, $parsedUrl['query']);
+        $this->clearUrl($url, $parsedUrl['query'] ?? '');
     }
 
     /**


### PR DESCRIPTION
- removes php notice when url does not have querys
- fixes hmac, the verification returned valid on invalid, and invalid on valid